### PR TITLE
MS Autohide body scrollbar

### DIFF
--- a/assets/css/2-basics/_body-element.sass
+++ b/assets/css/2-basics/_body-element.sass
@@ -8,3 +8,4 @@ body
   padding: 0
   -webkit-font-smoothing: antialiased
   -webkit-text-size-adjust: 100%
+  -ms-overflow-style: -ms-autohiding-scrollbar


### PR DESCRIPTION
This avoid the jump when the scrollbar is removed by toggling the menu
on ms browsers aka. IE and Edge.
